### PR TITLE
Permanently redirecting `postResolveObjects` to `getResolveObjects`.

### DIFF
--- a/apps/api-docs/CHANGELOG.md
+++ b/apps/api-docs/CHANGELOG.md
@@ -11,6 +11,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 
+-   Revised response types for `getResolveObjects` and `postResolveObjects`.
+
 ### Deprecated
 
 ### Fixed

--- a/apps/api-docs/public/v2/openapi.yaml
+++ b/apps/api-docs/public/v2/openapi.yaml
@@ -400,6 +400,17 @@ components:
   responses:
     "204":
       description: The request completed successfully. No further information is provided.
+    "301":
+      description: The requested resource is available at another location, permanently, using the `GET` method.
+      headers:
+        Content-Type:
+          $ref: "#/components/headers/Content-Type"
+        Location:
+          $ref: "#/components/headers/Location"
+      content:
+        application/vnd.phylopic.v2+json:
+          schema:
+            $ref: "#/components/schemas/Link"
     "303":
       description: The requested resource should be loaded from another location.
       headers:
@@ -1604,7 +1615,9 @@ paths:
         - $ref: "#/components/parameters/namespace"
         - $ref: "#/components/parameters/objectIDs"
       responses:
-        "303":
+        "307":
+          $ref: "#/components/responses/307"
+        "308":
           description: A matching node was found.
           headers:
             Location:
@@ -1650,19 +1663,10 @@ paths:
               items:
                 type: string
       responses:
-        "303":
-          description: A matching node was found.
-          headers:
-            Location:
-              $ref: "#/components/headers/Location"
-          content:
-            application/vnd.phylopic.v2+json:
-              schema:
-                $ref: "#/components/schemas/TitledLink"
+        "301":
+          $ref: "#/components/responses/301"
         "400":
           $ref: "#/components/responses/400"
-        "404":
-          $ref: "#/components/responses/404"
         "406":
           $ref: "#/components/responses/406"
         "410":

--- a/apps/api/CHANGELOG.md
+++ b/apps/api/CHANGELOG.md
@@ -18,6 +18,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+-   Validations were always of type `BAD_REQUEST_BODY` even when the field was in the parameters.
+
 ### Removed
 
 ### Security

--- a/apps/api/CHANGELOG.md
+++ b/apps/api/CHANGELOG.md
@@ -11,6 +11,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 
+-   `postResolveObjects` returns a permanent redirect to `getResolveObjects`.
+-   `getResolveObjects` does not include `POST` as an allowed method.
+
 ### Deprecated
 
 ### Fixed

--- a/apps/api/src/lambdas/dynamic.ts
+++ b/apps/api/src/lambdas/dynamic.ts
@@ -290,7 +290,7 @@ const route: (event: APIGatewayProxyEvent) => Promise<APIGatewayProxyResult> = (
                             ...getParameters(event.pathParameters, ["authority", "namespace"]),
                             ...getEmbedParameters(event.queryStringParameters, NODE_EMBEDDED_PARAMETERS),
                         },
-                        SERVICE,
+                        undefined,
                     )
                 }
                 default: {

--- a/apps/api/src/operations/getResolveObjects.ts
+++ b/apps/api/src/operations/getResolveObjects.ts
@@ -85,10 +85,10 @@ export const GetResolveObjects: Operation<GetResolveObjectsParameters, GetResolv
         body: stringifyNormalized(link),
         headers: {
             ...DATA_HEADERS,
-            ...createRedirectHeaders(link.href, false),
-            "access-control-allow-methods": "OPTIONS,GET,POST",
+            ...createRedirectHeaders(link.href, true),
+            "access-control-allow-methods": "OPTIONS,GET",
         },
-        statusCode: 303,
+        statusCode: 308,
     } as APIGatewayProxyResult
 }
 export default GetResolveObjects

--- a/apps/api/src/operations/getResolveObjects.ts
+++ b/apps/api/src/operations/getResolveObjects.ts
@@ -53,7 +53,7 @@ const getRedirect = async (
             throw new APIError(404, [
                 {
                     developerMessage: "Object could not be found. None of the IDs matched.",
-                    field: "body",
+                    field: "objectIDs",
                     type: "RESOURCE_NOT_FOUND",
                     userMessage: USER_MESSAGE,
                 },

--- a/apps/api/src/operations/postResolveObjects.ts
+++ b/apps/api/src/operations/postResolveObjects.ts
@@ -22,7 +22,7 @@ const getRedirectLink = (
     objectIDs: readonly ObjectID[],
     queryParameters: Readonly<Record<string, string | number | boolean | undefined>>,
 ): Link & { __WARNING__: string } => ({
-    __WARNING__: "This method is obsolete, and will return 410 (Gone) in the future.",
+    __WARNING__: "This method is deprecated, and will return 410 (Gone) in the future.",
     href: `/resolve/${encodeURIComponent(authority ?? "")}/${encodeURIComponent(namespace ?? "")}${createSearch({
         ...queryParameters,
         objectIDs: objectIDs.join(","),

--- a/apps/api/src/operations/postResolveObjects.ts
+++ b/apps/api/src/operations/postResolveObjects.ts
@@ -1,17 +1,14 @@
-import { DATA_MEDIA_TYPE, isResolveObjectParameters, ResolveObjectParameters, TitledLink } from "@phylopic/api-models"
-import { Authority, createSearch, Namespace, ObjectID, ObjectIDs, stringifyNormalized, UUID } from "@phylopic/utils"
-import { APIGatewayProxyResult } from "aws-lambda"
-import BUILD from "../build/BUILD"
-import checkBuild from "../build/checkBuild"
+import { DATA_MEDIA_TYPE, isResolveObjectParameters, Link, ResolveObjectParameters } from "@phylopic/api-models"
+import { Authority, createSearch, isNormalizedText, Namespace, ObjectID, stringifyNormalized } from "@phylopic/utils"
 import APIError from "../errors/APIError"
 import { DataRequestHeaders } from "../headers/requests/DataRequestHeaders"
 import createRedirectHeaders from "../headers/responses/createRedirectHeaders"
 import DATA_HEADERS from "../headers/responses/DATA_HEADERS"
 import checkAccept from "../mediaTypes/checkAccept"
 import checkContentType from "../mediaTypes/checkContentType"
-import { PgClientService } from "../services/PgClientService"
 import validate from "../validation/validate"
 import { Operation } from "./Operation"
+import { APIGatewayProxyResult } from "aws-lambda"
 const ACCEPT = `application/json,${DATA_MEDIA_TYPE}`
 const USER_MESSAGE = "There was a problem with an attempt to find taxonomic data."
 export type PostResolveObjectsParameters = DataRequestHeaders & {
@@ -19,78 +16,18 @@ export type PostResolveObjectsParameters = DataRequestHeaders & {
 } & Partial<Omit<ResolveObjectParameters, "objectID">> & {
         readonly body?: string
     }
-export type PostResolveObjectsService = PgClientService
-const getAlternate = (
+const getRedirectLink = (
     authority: Authority,
     namespace: Namespace,
     objectIDs: readonly ObjectID[],
     queryParameters: Readonly<Record<string, string | number | boolean | undefined>>,
-) =>
-    `/resolve/${encodeURIComponent(authority ?? "")}/${encodeURIComponent(namespace ?? "")}${createSearch({
+): Link & { __WARNING__: string } => ({
+    __WARNING__: "This method is obsolete, and will return 410 (Gone) in the future.",
+    href: `/resolve/${encodeURIComponent(authority ?? "")}/${encodeURIComponent(namespace ?? "")}${createSearch({
         ...queryParameters,
         objectIDs: objectIDs.join(","),
-    })}`
-const getRedirect = async (
-    service: PgClientService,
-    authority: Authority | undefined,
-    namespace: Namespace | undefined,
-    objectIDs: ObjectID[],
-    queryParameters: Readonly<Record<string, string | number | boolean | undefined>>,
-): Promise<TitledLink & { __WARNING__: string }> => {
-    if (!authority || !namespace) {
-        throw new APIError(400, [
-            {
-                developerMessage: "Not enough information to resolve.",
-                field: authority ? "namespace" : "authority",
-                type: "BAD_REQUEST_PARAMETERS",
-                userMessage: USER_MESSAGE,
-            },
-        ])
-    }
-    if (authority === "phylopic.org") {
-        throw new APIError(400, [
-            {
-                developerMessage: "This method is not meant to be used for PhyloPic objects.",
-                field: "authority",
-                type: "BAD_REQUEST_PARAMETERS",
-                userMessage: USER_MESSAGE,
-            },
-        ])
-    }
-    const client = await service.createPgClient()
-    let link: TitledLink
-    try {
-        const result = await client.query<{ node_uuid: UUID; title: string | null }>(
-            'SELECT node_uuid,title FROM node_external WHERE authority=$1::character varying AND "namespace"=$2::character varying AND objectid=ANY($3::character varying[]) AND build=$4::bigint ORDER BY array_position($3::character varying[],objectid) LIMIT 1',
-            [authority, namespace, objectIDs, BUILD],
-        )
-        if (result.rowCount !== 1) {
-            throw new APIError(404, [
-                {
-                    developerMessage: "Object could not be found. None of the IDs matched.",
-                    field: "body",
-                    type: "RESOURCE_NOT_FOUND",
-                    userMessage: USER_MESSAGE,
-                },
-            ])
-        }
-        link = {
-            href: `/nodes/` + encodeURIComponent(result.rows[0].node_uuid) + createSearch(queryParameters),
-            title: result.rows[0].title ?? "",
-        }
-    } finally {
-        await service.deletePgClient(client)
-    }
-    return {
-        ...link,
-        __WARNING__: `This method is deprecated! Please use \`GET ${getAlternate(
-            authority,
-            namespace,
-            objectIDs,
-            queryParameters,
-        )}\`.`,
-    }
-}
+    })}`,
+})
 const getObjectIDsFromBody = (body: string | null) => {
     if (!body) {
         throw new APIError(400, [
@@ -115,10 +52,10 @@ const getObjectIDsFromBody = (body: string | null) => {
             },
         ])
     }
-    if (!Array.isArray(objectIDs) || !objectIDs.every(item => typeof item === "string" && item.length > 0)) {
+    if (!Array.isArray(objectIDs) || !objectIDs.every(item => isNormalizedText(item))) {
         throw new APIError(400, [
             {
-                developerMessage: "Expected body to be an array of nonempty strings.",
+                developerMessage: "Expected body to be an array of ID strings.",
                 field: "body",
                 type: "BAD_REQUEST_BODY",
                 userMessage: USER_MESSAGE,
@@ -127,10 +64,12 @@ const getObjectIDsFromBody = (body: string | null) => {
     }
     return objectIDs
 }
-export const postResolveObjects: Operation<PostResolveObjectsParameters, PostResolveObjectsService> = async (
-    { accept, body, "content-type": contentType, ...queryAndPathParameters },
-    service,
-) => {
+export const postResolveObjects: Operation<PostResolveObjectsParameters> = async ({
+    accept,
+    body,
+    "content-type": contentType,
+    ...queryAndPathParameters
+}) => {
     checkAccept(accept, DATA_MEDIA_TYPE)
     checkContentType(contentType, ACCEPT)
     validate({ ...queryAndPathParameters, objectID: "-" }, isResolveObjectParameters, USER_MESSAGE)
@@ -146,21 +85,16 @@ export const postResolveObjects: Operation<PostResolveObjectsParameters, PostRes
     }
     const objectIDs = getObjectIDsFromBody(body)
     const { authority, namespace, ...queryParameters } = queryAndPathParameters
-    if (queryParameters.build) {
-        checkBuild(queryParameters.build, USER_MESSAGE)
-    }
-    const link = await getRedirect(service, authority, namespace, objectIDs, queryParameters)
-    const alternate = getAlternate(authority as Authority, namespace as Namespace, objectIDs, queryParameters)
+    const link = getRedirectLink(authority ?? "", namespace ?? "", objectIDs, queryParameters)
     return {
         body: stringifyNormalized(link),
         headers: {
             ...DATA_HEADERS,
-            ...createRedirectHeaders(link.href, false),
-            "access-control-allow-methods": "OPTIONS,GET,POST",
+            ...createRedirectHeaders(link.href, true),
+            "access-control-allow-methods": "OPTIONS,GET",
             deprecation: "version=v2",
-            link: `<https://api.phylopic.org${alternate}>; rel="alternate"`,
         },
-        statusCode: 303,
+        statusCode: 301,
     } as APIGatewayProxyResult
 }
 export default postResolveObjects

--- a/apps/api/src/validation/convertValidationFaultsToErrors.ts
+++ b/apps/api/src/validation/convertValidationFaultsToErrors.ts
@@ -6,7 +6,7 @@ const convertValidationFaultsToErrors = (faults: readonly ValidationFault[], use
             ({
                 developerMessage: fault.message,
                 field: fault.field,
-                type: "BAD_REQUEST_BODY",
+                type: fault.field === "body" ? "BAD_REQUEST_BODY" : "BAD_REQUEST_PARAMETERS",
                 userMessage,
             } as Error),
     )


### PR DESCRIPTION
Now that `postResolveObjects` has been deprecated (since 2023 April 25), this PR permanently redirects all requests to it to `getResolveObjects`.

This PR also modifies `getResolveObjects` to return a permanent redirect (`308`) when a node is found. (This makes sense when the `build` is included. If the `build` is not included, a temporary `307` redirect is returned, anyway.)