### PR TITLE
Feature: Sanitized vector files

### DIFF
--- a/apps/api-docs/CHANGELOG.md
+++ b/apps/api-docs/CHANGELOG.md
@@ -11,8 +11,6 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 
--   Description of `vectorFile`.
-
 ### Deprecated
 
 ### Fixed
@@ -20,6 +18,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Removed
 
 ### Security
+
+## [2.6.1] - 2023-12-18
+
+### Changed
+
+-   Description of `vectorFile`.
 
 ## [2.6.0] - 2023-05-18
 

--- a/apps/api-docs/CHANGELOG.md
+++ b/apps/api-docs/CHANGELOG.md
@@ -11,6 +11,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 
+-   Description of `vectorFile`.
+
 ### Deprecated
 
 ### Fixed

--- a/apps/api-docs/package.json
+++ b/apps/api-docs/package.json
@@ -31,5 +31,5 @@
         "predeploy": "yarn test",
         "test": "swagger-cli validate ./public/v2/openapi.yaml"
     },
-    "version": "2.6.0"
+    "version": "2.6.1"
 }

--- a/apps/api-docs/public/v2/index.html
+++ b/apps/api-docs/public/v2/index.html
@@ -1,7 +1,7 @@
 <!DOCTYPE html>
 <html lang="en" prefix="og: https://ogp.me/ns#">
 <head>
-<title>PhyloPic API 2.6.0 Documentation</title>
+<title>PhyloPic API 2.6.1 Documentation</title>
 <meta charset="UTF-8">
 <meta property="og:description" content="Application Programming Interface documentation for PhyloPic, an open database of free silhouette images of animals, plants, and other life forms, available for reuse under Creative Commons licenses."/>
 <meta property="og:title" content="PhyloPic API 2.2.0 Documentation"/>
@@ -39,7 +39,7 @@
 <script>    
 window.onload = function () {
   const ui = SwaggerUIBundle({
-    url: "http://api-docs.phylopic.org/v2/openapi.yaml?v=2.6.0",
+    url: "http://api-docs.phylopic.org/v2/openapi.yaml?v=2.6.1",
     dom_id: "#openapi"
   })
 }

--- a/apps/api-docs/public/v2/openapi.yaml
+++ b/apps/api-docs/public/v2/openapi.yaml
@@ -709,8 +709,7 @@ components:
                 vectorFile:
                   allOf:
                     - $ref: "#/components/schemas/MediaLink"
-                    - description: A link to the vector image file as it was submitted. Always in SVG format.
-                      nullable: true
+                    - description: A link to a vector file generated from the largest raster file. This will always be black on a transparent backgounrd, cropped to the size of the silhouette. It may look different from the source file.
     ImageWithEmbedded:
       description: An image with related entities embedded.
       required:

--- a/apps/publish/CHANGELOG.md
+++ b/apps/publish/CHANGELOG.md
@@ -21,6 +21,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Security
 
+## [1.4.0] - 2023-12-18
+
+### Added
+
+-   Sanitization of `vectorFile` images (re-vectorized from largest raster).
+
 ## [1.3.1] - 2023-05-14
 
 ### Added

--- a/apps/publish/CHANGELOG.md
+++ b/apps/publish/CHANGELOG.md
@@ -9,8 +9,6 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
--   Sanitization of `vectorFile` images (re-vectorized from largest raster).
-
 ### Changed
 
 ### Deprecated

--- a/apps/publish/CHANGELOG.md
+++ b/apps/publish/CHANGELOG.md
@@ -9,6 +9,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
+-   Sanitization of `vectorFile` images (re-vectorized from largest raster).
+
 ### Changed
 
 ### Deprecated

--- a/apps/publish/package.json
+++ b/apps/publish/package.json
@@ -48,5 +48,5 @@
         "upload:images": "aws s3 sync --acl public-read ./.s3/images.phylopic.org s3://images.phylopic.org/"
     },
     "type": "module",
-    "version": "1.3.1"
+    "version": "1.4.0"
 }

--- a/apps/publish/process_vector.sh
+++ b/apps/publish/process_vector.sh
@@ -69,6 +69,12 @@ for prefix in 0 1 2 3 4 5 6 7 8 9 a b c d e f; do
     magick convert \
         $prefix'*.raster.png' \
         -set filename:basename '%[basename]' \
+        -background white \
+        -alpha remove \
+        '%[filename:basename].bmp'
+    magick convert \
+        $prefix'*.raster.png' \
+        -set filename:basename '%[basename]' \
         -define png:compression-level=9 \
         '%[filename:basename].1536.png' &
     magick convert \
@@ -135,7 +141,18 @@ for prefix in 0 1 2 3 4 5 6 7 8 9 a b c d e f; do
     wait
 done
 
-echo "[VECTOR] Created raster variants. Cleaning up raster bases..."
+echo "[VECTOR] Created raster variants. Sanitizing vector files..."
+for file in *.raster.bmp; do
+    dest=$(echo $file |
+        sed 's/\.raster\.bmp$/.vector.svg/')
+    potrace \
+        $file \
+        --svg \
+        --output $dest
+done
+
+echo "[VECTOR] Sanitized vector files. Cleaning up raster bases..."
+rm *.raster.bmp
 rm *.raster.png
 cd ../..
 

--- a/apps/www/CHANGELOG.md
+++ b/apps/www/CHANGELOG.md
@@ -13,8 +13,6 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 
--   Verbiage for vector file in Image Downloads.
-
 ### Deprecated
 
 ### Fixed
@@ -22,6 +20,16 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Removed
 
 ### Security
+
+## [2.6.11] - 2023-12-18
+
+### Added
+
+-   Source file in Image Downloads.
+
+### Changed
+
+-   Verbiage for vector file in Image Downloads.
 
 ## [2.6.10] - 2023-12-18
 

--- a/apps/www/CHANGELOG.md
+++ b/apps/www/CHANGELOG.md
@@ -9,8 +9,6 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
--   Source file in Image Downloads.
-
 ### Changed
 
 ### Deprecated

--- a/apps/www/CHANGELOG.md
+++ b/apps/www/CHANGELOG.md
@@ -9,7 +9,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
+-   Source file in Image Downloads.
+
 ### Changed
+
+-   Verbiage for vector file in Image Downloads.
 
 ### Deprecated
 

--- a/apps/www/package.json
+++ b/apps/www/package.json
@@ -52,5 +52,5 @@
         "start": "next start",
         "unused": "next-unused"
     },
-    "version": "2.6.10"
+    "version": "2.6.11"
 }

--- a/apps/www/src/views/ImageFilesView/index.tsx
+++ b/apps/www/src/views/ImageFilesView/index.tsx
@@ -12,8 +12,18 @@ export interface Props {
     value: Image
 }
 const EXTENSION_LINKS: Readonly<Record<string, string>> = {
+    bmp: "//www.loc.gov/preservation/digital/formats/fdd/fdd000189.shtml",
+    gif: "//www.loc.gov/preservation/digital/formats/fdd/fdd000133.shtml",
+    jpeg: "//jpeg.org/",
     png: "http://www.libpng.org/pub/png/spec/1.2/PNG-Contents.html",
-    svg: "https://www.w3.org/TR/SVG/",
+    svg: "//www.w3.org/TR/SVG/",
+}
+const EXTENSION_TITLES: Readonly<Record<string, string>> = {
+    bmp: "Microsoft Windows Bitmap",
+    gif: "Graphics Interchange Format",
+    jpeg: "Joint Photographic Experts Group",
+    png: "Portable Network Graphics",
+    svg: "Scalable Vector Graphics",
 }
 const ImageFilesView: FC<Props> = ({ value }) => {
     const licenseShort = useLicenseText(value._links.license.href, true)
@@ -37,29 +47,24 @@ const ImageFilesView: FC<Props> = ({ value }) => {
     return (
         <table>
             <tbody>
-                {value._links.vectorFile && (
-                    <tr key="vector">
-                        <th>
-                            {sourceFileExtension === "SVG" ? "Vector" : "Vectorized"} File (
-                            <a
-                                href={EXTENSION_LINKS.svg}
-                                onClick={() => customEvents.clickLink("svg", EXTENSION_LINKS.svg, "SVG", "link")}
-                                rel="external"
-                            >
-                                <abbr title="Scalable Vector Graphics">SVG</abbr>
-                            </a>
-                            )
-                        </th>
-                        <td className={styles.cellList}>
-                            <DownLoadLink filenamePrefix={filenamePrefix} link={value._links.vectorFile} />
-                            &nbsp;
-                            <i>
-                                (Scales to any resolution.
-                                {sourceFileExtension !== "SVG" && " May look different from original."})
-                            </i>
-                        </td>
-                    </tr>
-                )}
+                <tr key="vector">
+                    <th>
+                        {sourceFileExtension === "SVG" ? "Vector" : "Vectorized"} File (
+                        <a
+                            href={EXTENSION_LINKS.svg}
+                            onClick={() => customEvents.clickLink("svg", EXTENSION_LINKS.svg, "SVG", "link")}
+                            rel="external"
+                        >
+                            <abbr title={EXTENSION_TITLES.svg}>SVG</abbr>
+                        </a>
+                        )
+                    </th>
+                    <td className={styles.cellList}>
+                        <DownLoadLink filenamePrefix={filenamePrefix} link={value._links.vectorFile} />
+                        &nbsp;
+                        <i>(Scales to any resolution. May look different from original.)</i>
+                    </td>
+                </tr>
                 <tr key="raster">
                     <th>
                         Alternate Sizes (
@@ -68,7 +73,7 @@ const ImageFilesView: FC<Props> = ({ value }) => {
                             onClick={() => customEvents.clickLink("png_alternate", EXTENSION_LINKS.png, "PNG", "link")}
                             rel="external"
                         >
-                            <abbr title="Portable Network Graphics">PNG</abbr>
+                            <abbr title={EXTENSION_TITLES.png}>PNG</abbr>
                         </a>
                         )
                     </th>
@@ -86,7 +91,7 @@ const ImageFilesView: FC<Props> = ({ value }) => {
                             onClick={() => customEvents.clickLink("png_thumbnail", EXTENSION_LINKS.png, "PNG", "link")}
                             rel="external"
                         >
-                            <abbr title="Portable Network Graphics">PNG</abbr>
+                            <abbr title={EXTENSION_TITLES.png}>PNG</abbr>
                         </a>
                         )
                     </th>
@@ -94,6 +99,37 @@ const ImageFilesView: FC<Props> = ({ value }) => {
                         {thumbnailFiles.map(link => (
                             <DownLoadLink key={link.href} filenamePrefix={filenamePrefix} link={link} />
                         ))}
+                    </td>
+                </tr>
+                <tr key="source">
+                    <th>
+                        Original File (
+                        <a
+                            href={EXTENSION_LINKS[sourceFileExtension.toLowerCase()]}
+                            onClick={() =>
+                                customEvents.clickLink(
+                                    "source",
+                                    EXTENSION_LINKS[sourceFileExtension.toLowerCase()],
+                                    sourceFileExtension,
+                                    "link",
+                                )
+                            }
+                            rel="external"
+                        >
+                            <abbr title={EXTENSION_TITLES[sourceFileExtension.toLowerCase()]}>
+                                {sourceFileExtension}
+                            </abbr>
+                        </a>
+                        )
+                    </th>
+                    <td className={styles.cellList}>
+                        <DownLoadLink filenamePrefix={filenamePrefix} link={value._links.sourceFile} />
+                        {sourceFileExtension === "SVG" ? (
+                            <>
+                                &nbsp;
+                                <i>(Scales to any resolution.)</i>
+                            </>
+                        ) : null}
                     </td>
                 </tr>
             </tbody>


### PR DESCRIPTION
To address [issues with source SVG files](https://github.com/keesey/phylopic/issues/15), this PR adds a step to the publication process of images submitted as SVG files. where `vectorFile` is generated using `potrace` from the largest raster file (similar to how `vectorFile` is generated for raster images). This guarantees a "sanitized" version of the vector file (although it may lose some detail from the original).

This PR also includes a slight update to the API documentation and an update to the Image Downloads section of Image Pages, adding access to the original file.