### PR TITLE
Feature: Suppress images

### DIFF
--- a/apps/api-docs/CHANGELOG.md
+++ b/apps/api-docs/CHANGELOG.md
@@ -19,6 +19,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Security
 
+## [2.7.0] - 2025-01-02
+
+### Changed
+
+-   Updated version for parity.
+
 ## [2.6.2] - 2024-04-13
 
 ### Added

--- a/apps/api-docs/package.json
+++ b/apps/api-docs/package.json
@@ -32,5 +32,5 @@
         "predeploy": "yarn test",
         "test": "swagger-cli validate ./public/v2/openapi.yaml"
     },
-    "version": "2.6.3"
+    "version": "2.7.0"
 }

--- a/apps/api-docs/public/v2/index.html
+++ b/apps/api-docs/public/v2/index.html
@@ -1,7 +1,7 @@
 <!DOCTYPE html>
 <html lang="en" prefix="og: https://ogp.me/ns#">
 <head>
-<title>PhyloPic API 2.6.3 Documentation</title>
+<title>PhyloPic API 2.7.0 Documentation</title>
 <meta charset="UTF-8">
 <meta property="og:description" content="Application Programming Interface documentation for PhyloPic, an open database of free silhouette images of animals, plants, and other life forms, available for reuse under Creative Commons licenses."/>
 <meta property="og:title" content="PhyloPic API 2.2.0 Documentation"/>
@@ -39,7 +39,7 @@
 <script>    
 window.onload = function () {
   const ui = SwaggerUIBundle({
-    url: "http://api-docs.phylopic.org/v2/openapi.yaml?v=2.6.3",
+    url: "http://api-docs.phylopic.org/v2/openapi.yaml?v=2.7.0",
     dom_id: "#openapi"
   })
 }

--- a/apps/api/CHANGELOG.md
+++ b/apps/api/CHANGELOG.md
@@ -19,11 +19,17 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Security
 
+## [2.7.0] - 2025-01-02
+
+### Changed
+
+-   Filtering out unlisted images and contributors from lists.
+
 ## [2.6.3] - 2024-12-03
 
 ### Changed
 
--   Updated architecture to AWS Graviton2 processor (arm64).
+-   Updated architecture to AWS Graviton2 processor (`arm64`).
 
 ## [2.6.2] - 2024-11-04
 

--- a/apps/api/package.json
+++ b/apps/api/package.json
@@ -43,5 +43,5 @@
         "dev": "sls offline --httpPort 3003",
         "lint": "eslint --fix ./**/*.[jt]s"
     },
-    "version": "2.6.3"
+    "version": "2.7.0"
 }

--- a/apps/api/src/operations/getContributors.ts
+++ b/apps/api/src/operations/getContributors.ts
@@ -40,6 +40,7 @@ const getQueryBuilder = (parameters: ContributorListParameters, results: "total"
     } else {
         builder.add(`SELECT ${selection} FROM contributor WHERE build=$::bigint`, [BUILD])
     }
+    builder.add("AND contributor.unlisted=0::bit")
     if (results === "total") {
         // Add nothing
     } else {

--- a/apps/api/src/operations/getImages.ts
+++ b/apps/api/src/operations/getImages.ts
@@ -83,6 +83,7 @@ SELECT ${selection} FROM node_name
     } else {
         builder.add(`SELECT ${selection} FROM image WHERE build=$::bigint`, [BUILD])
     }
+    builder.add("AND image.unlisted=0::bit")
     addFilterToQuery(parameters, builder)
     if (results === "total") {
         // Add nothing

--- a/apps/edit/CHANGELOG.md
+++ b/apps/edit/CHANGELOG.md
@@ -23,7 +23,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 
-- Redirecting to original target node when an external is deactivated, instead of the Nodes Page.
+-   Redirecting to original target node when an external is deactivated, instead of the Nodes Page.
 
 ## [1.5.5] - 2024-06-21
 

--- a/apps/edit/CHANGELOG.md
+++ b/apps/edit/CHANGELOG.md
@@ -19,6 +19,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Security
 
+## [1.7.0] - 2025-01-02
+
+### Added
+
+-   Control for whether an image is listed or not.
+
 ## [1.6.0] - 2024-11-25
 
 ### Changed

--- a/apps/edit/package.json
+++ b/apps/edit/package.json
@@ -44,5 +44,5 @@
         "lint": "TIMING=1 next lint",
         "unused": "next-unused"
     },
-    "version": "1.6.0"
+    "version": "1.7.0"
 }

--- a/apps/edit/pages/externals/[authority]/[namespace]/[objectid]/index.tsx
+++ b/apps/edit/pages/externals/[authority]/[namespace]/[objectid]/index.tsx
@@ -92,7 +92,9 @@ const Content: FC<Props> = ({ authority, namespace, objectID }) => {
         if (confirm("Are you sure?")) {
             ;(async () => {
                 try {
-                    const route = nodeUUID ? `/nodes/${encodeURIComponent(nodeUUID)}` : `/externals/${encodeURIComponent(authority)}/${encodeURIComponent(namespace)}`
+                    const route = nodeUUID
+                        ? `/nodes/${encodeURIComponent(nodeUUID)}`
+                        : `/externals/${encodeURIComponent(authority)}/${encodeURIComponent(namespace)}`
                     await axios.delete(key)
                     mutate(undefined, { revalidate: true })
                     await router.push(route)

--- a/apps/edit/src/editors/ImageEditor/ListedEditor.tsx
+++ b/apps/edit/src/editors/ImageEditor/ListedEditor.tsx
@@ -1,0 +1,34 @@
+import { Image } from "@phylopic/source-models"
+import { fetchJSON } from "@phylopic/ui"
+import { UUID } from "@phylopic/utils"
+import { FC } from "react"
+import useSWR from "swr"
+import useModifiedPatcher from "~/swr/useModifiedPatcher"
+export type Props = {
+    uuid: UUID
+}
+const ListedEditor: FC<Props> = ({ uuid }) => {
+    const key = `/api/images/_/${encodeURIComponent(uuid)}`
+    const response = useSWR<Image & { uuid: UUID }>(key, fetchJSON)
+    const { data } = response
+    const patcher = useModifiedPatcher(key, response)
+    if (!data) {
+        return null
+    }
+    return (
+        <input
+            type="checkbox"
+            checked={!data.unlisted}
+            onChange={() => {
+                if (data.unlisted) {
+                    if (confirm("Are you sure you want to restore this image?")) {
+                        patcher({ unlisted: false })
+                    }
+                } else if (confirm("Are you sure you want to remove this image from the public listing?")) {
+                    patcher({ unlisted: true })
+                }
+            }}
+        />
+    )
+}
+export default ListedEditor

--- a/apps/edit/src/editors/ImageEditor/index.tsx
+++ b/apps/edit/src/editors/ImageEditor/index.tsx
@@ -5,6 +5,7 @@ import ContributorViewer from "./ContributorViewer"
 import Controls from "./Controls"
 import styles from "./index.module.scss"
 import LicenseEditor from "./LicenseEditor"
+import ListedEditor from "./ListedEditor"
 import NodesEditor from "./NodesEditor"
 import SponsorEditor from "./SponsorEditor"
 export type Props = {
@@ -29,6 +30,10 @@ const ImageEditor: FC<Props> = ({ uuid }) => {
                 <dt>License</dt>
                 <dd>
                     <LicenseEditor uuid={uuid} />
+                </dd>
+                <dt>Listed?</dt>
+                <dd>
+                    <ListedEditor uuid={uuid} />
                 </dd>
                 <dt>Nodes</dt>
                 <dd>

--- a/apps/edit/src/styles/globals.scss
+++ b/apps/edit/src/styles/globals.scss
@@ -11,6 +11,7 @@ body {
 
 a {
     color: inherit;
+
     &:hover {
         opacity: 0.75;
     }
@@ -45,20 +46,30 @@ textarea {
     font-family: Verdana, sans-serif;
     font-size: inherit;
 }
+
 input,
 textarea {
+    accent-color: black;
     width: 100%;
 }
+
 textarea {
     border-radius: 1em;
     padding: 1em;
 }
-input[type="submit"] {
+
+input[type=checkbox] {
+    cursor: pointer;
+    width: unset;
+}
+
+input[type=submit] {
     background-color: black;
     border-radius: 1em;
     color: white;
     cursor: pointer;
     padding: 1em;
+
     &:hover {
         opacity: 0.75;
     }
@@ -66,6 +77,7 @@ input[type="submit"] {
 
 .editable {
     cursor: text;
+
     &:hover {
         opacity: 0.75;
     }
@@ -73,6 +85,7 @@ input[type="submit"] {
 
 .changed {
     color: red;
+
     .dark {
         background-color: red;
     }
@@ -90,22 +103,27 @@ input[type="submit"] {
 
 .nomen {
     font-family: Georgia, serif;
+
     .citation,
     &.citation {
         font-variant: small-caps;
     }
+
     .comment,
     &.comment {
         opacity: 0.5;
     }
+
     .operator,
     &.operator {
         font-family: Verdana, sans-serif;
     }
+
     .scientific,
     &.scientific {
         font-style: italic;
     }
+
     .rank,
     &.rank {
         font-style: italic;
@@ -118,21 +136,24 @@ ul {
     list-style-type: none;
 }
 
-nav.pagination > ul {
+nav.pagination>ul {
     display: flex;
     flex-direction: row;
     flex-wrap: wrap;
     gap: 1em;
-    > li {
+
+    >li {
         display: inline-flex;
     }
 }
 
 a[role="button"] {
     text-decoration: underline;
+
     &::after {
         content: "]";
     }
+
     &::before {
         content: "[";
     }
@@ -145,6 +166,7 @@ code {
 dt {
     font-weight: bold;
 }
+
 main {
     margin: 0 auto;
     max-width: 11in;

--- a/apps/publish/CHANGELOG.md
+++ b/apps/publish/CHANGELOG.md
@@ -19,6 +19,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Security
 
+## [1.7.0] - 2025-01-02
+
+### Added
+
+-   Handling for unlisted images and contributors.
+
 ## [1.6.2] - 2025-01-02
 
 ### Fixed

--- a/apps/publish/package.json
+++ b/apps/publish/package.json
@@ -51,5 +51,5 @@
         "upload:images": "aws s3 sync --acl public-read ./.s3/images.phylopic.org s3://images.phylopic.org/"
     },
     "type": "module",
-    "version": "1.6.2"
+    "version": "1.7.0"
 }

--- a/packages/source-client/CHANGELOG.md
+++ b/packages/source-client/CHANGELOG.md
@@ -19,6 +19,20 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Security
 
+## [1.2.0] - 2025-01-02
+
+### Added
+
+-   New property: `Image.unlisted`.
+
+### Changed
+
+-   Made `normalizeBoolean()` more robust.
+
+### Fixed
+
+-   `normalizeImage()` included some nonexistent properties.
+
 ## [1.1.5] - 2024-11-04
 
 ### Changed

--- a/packages/source-client/package.json
+++ b/packages/source-client/package.json
@@ -66,5 +66,5 @@
         "lint": "TIMING=1 eslint --fix src/**/*.ts*"
     },
     "types": "./dist/index.d.ts",
-    "version": "1.1.5"
+    "version": "1.2.0"
 }

--- a/packages/source-client/src/implementations/pg/constants/IMAGE_FIELDS.ts
+++ b/packages/source-client/src/implementations/pg/constants/IMAGE_FIELDS.ts
@@ -22,5 +22,6 @@ export const IMAGE_FIELDS: ReadonlyArray<EditField<Image & { uuid: UUID }>> = [
     },
     { column: "specific_uuid", insertable: true, property: "specific", type: "uuid", updateable: true },
     { column: "sponsor", insertable: true, property: "sponsor", type: "character varying", updateable: true },
+    { column: "unlisted", insertable: true, property: "unlisted", type: "bit", updateable: true },
     { column: "uuid", insertable: true, property: "uuid", type: "uuid", updateable: false },
 ]

--- a/packages/source-client/src/implementations/pg/normalization/normalizeBoolean.ts
+++ b/packages/source-client/src/implementations/pg/normalization/normalizeBoolean.ts
@@ -1,3 +1,3 @@
 export const normalizeBoolean = (value: any): boolean => {
-    return value === "1"
+    return String(value) === "1"
 }

--- a/packages/source-client/src/implementations/pg/normalization/normalizeImage.ts
+++ b/packages/source-client/src/implementations/pg/normalization/normalizeImage.ts
@@ -4,7 +4,6 @@ import { normalizeEntity } from "./normalizeEntity"
 export const normalizeImage = <T extends Image>(value: T): T => {
     return {
         ...normalizeEntity(value),
-        accepted: normalizeBoolean(value.accepted),
-        submitted: normalizeBoolean(value.submitted),
+        unlisted: normalizeBoolean(value.unlisted),
     }
 }

--- a/packages/source-models/CHANGELOG.md
+++ b/packages/source-models/CHANGELOG.md
@@ -19,6 +19,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Security
 
+## [1.1.0] - 2025-01-02
+
+### Added
+
+-   New property: `Image.unlisted`.
+
 ## [1.0.2] - 2024-04-13
 
 ### Changed

--- a/packages/source-models/package.json
+++ b/packages/source-models/package.json
@@ -62,5 +62,5 @@
         "test": "vitest --watch=false"
     },
     "types": "./dist/index.d.ts",
-    "version": "1.0.2"
+    "version": "1.1.0"
 }

--- a/packages/source-models/src/conversion/getImage.ts
+++ b/packages/source-models/src/conversion/getImage.ts
@@ -10,6 +10,6 @@ export const getImage = (submission: Submission & { submitted: true }, specific:
         modified: submission.created,
         specific,
         sponsor: submission.sponsor ?? null,
-        unlisted: false
+        unlisted: false,
     }
 }

--- a/packages/source-models/src/conversion/getImage.ts
+++ b/packages/source-models/src/conversion/getImage.ts
@@ -10,5 +10,6 @@ export const getImage = (submission: Submission & { submitted: true }, specific:
         modified: submission.created,
         specific,
         sponsor: submission.sponsor ?? null,
+        unlisted: false
     }
 }

--- a/packages/source-models/src/detection/isImage.ts
+++ b/packages/source-models/src/detection/isImage.ts
@@ -1,5 +1,6 @@
 import {
     invalidate,
+    isBoolean,
     isISOTimestamp,
     isLicenseURL,
     isNormalizedText,
@@ -20,6 +21,7 @@ export const isImage = (x: unknown, faultCollector?: ValidationFaultCollector): 
     isISOTimestamp((x as Image).modified, faultCollector?.sub("modified")) &&
     isUUIDv4((x as Image).specific, faultCollector?.sub("specific")) &&
     isNullOr(isNormalizedText)((x as Image).sponsor, faultCollector?.sub("sponsor")) &&
+    isBoolean((x as Image).unlisted) &&
     Boolean(
         (x as Image).attribution ||
             !(x as Image).license ||

--- a/packages/source-models/src/types/Image.ts
+++ b/packages/source-models/src/types/Image.ts
@@ -8,4 +8,5 @@ export type Image = Readonly<{
     general: UUID | null
     specific: UUID
     sponsor: string | null
+    unlisted: boolean
 }>

--- a/sql/CHANGELOG.md
+++ b/sql/CHANGELOG.md
@@ -19,6 +19,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Security
 
+## [2.3.0] - 2025-01-02
+
+### Added
+
+-   New source column: `image.unlisted`.
+-   New entities columns: `contributor.unlisted`, `image.unlisted`.
+
 ## [2.2.0] - 2023-03-24
 
 ### Added

--- a/sql/phylopic-entities.sql
+++ b/sql/phylopic-entities.sql
@@ -37,6 +37,7 @@ CREATE TABLE IF NOT EXISTS public.contributor
     json text COLLATE pg_catalog."default" NOT NULL,
     sort_index bigint NOT NULL,
     title character varying(64) COLLATE pg_catalog."default",
+    unlisted bit(1) NOT NULL DEFAULT (0)::bit(1),
     CONSTRAINT contributor_id PRIMARY KEY (uuid, build),
     CONSTRAINT contributor_sort_index_unique UNIQUE (sort_index, build)
 )
@@ -65,6 +66,7 @@ CREATE TABLE IF NOT EXISTS public.image
     title character varying(64) COLLATE pg_catalog."default" NOT NULL DEFAULT ''::character varying,
     modified timestamp without time zone NOT NULL,
     modified_file timestamp without time zone NOT NULL,
+    unlisted bit(1) NOT NULL DEFAULT (0)::bit(1),
     CONSTRAINT image_id PRIMARY KEY (uuid, build),
     CONSTRAINT image_contributor_fkey FOREIGN KEY (build, contributor_uuid)
         REFERENCES public.contributor (build, uuid) MATCH SIMPLE

--- a/sql/phylopic-source.sql
+++ b/sql/phylopic-source.sql
@@ -106,6 +106,7 @@ CREATE TABLE IF NOT EXISTS public.image
     created timestamp without time zone NOT NULL DEFAULT now(),
     modified timestamp without time zone NOT NULL DEFAULT now(),
     disabled bit(1) NOT NULL DEFAULT (0)::bit(1),
+    unlisted bit(1) NOT NULL DEFAULT (0)::bit(1),
     CONSTRAINT image_pkey PRIMARY KEY (uuid),
     CONSTRAINT image_contributor_uuid_fkey FOREIGN KEY (contributor_uuid)
         REFERENCES public.contributor (uuid) MATCH SIMPLE


### PR DESCRIPTION
Adds a new property to source images: `unlisted`. If true, then the image will not be listed in the API `/images` endpoint, but will be accessible with the UUID. Any contributor whose images are all unlisted will also be unlisted.